### PR TITLE
Fixes integration inactivation in the home organization loader

### DIFF
--- a/mpassid-voh-api/pom.xml
+++ b/mpassid-voh-api/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>fi.mpass</groupId>
 		<artifactId>mpassid-voh</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>mpassid-voh-api</artifactId>
 

--- a/mpassid-voh-api/src/main/java/fi/mpass/voh/api/config/IntegrationLoader.java
+++ b/mpassid-voh-api/src/main/java/fi/mpass/voh/api/config/IntegrationLoader.java
@@ -126,10 +126,11 @@ public class IntegrationLoader implements CommandLineRunner {
                                 .findByIdIdpAll(integration.getId());
                         if (existingIntegration.isPresent()) {
                             if (!existingIntegration.get().isActive()) {
-                                logger.info("Reloading inactive integration " + existingIntegration.get().getId() + ". Reactivating.");
+                                logger.info("Reloading inactive integration " + existingIntegration.get().getId()
+                                        + ". Reactivating.");
                                 existingIntegration.get().setStatus(0);
                             }
-                            
+
                             logger.debug("Comparing existing integration " + existingIntegration.get().getId()
                                     + " version " + existingIntegration.get().getVersion() + " to "
                                     + integration.getId() + " version " + integration.getVersion());
@@ -229,7 +230,7 @@ public class IntegrationLoader implements CommandLineRunner {
                                             }
                                         }
                                         if (d.getFieldName().contains("deploymentPhase")) {
-                                            existingIntegration.get().setDeploymentPhase((Integer)d.getRight());
+                                            existingIntegration.get().setDeploymentPhase((Integer) d.getRight());
                                         }
                                     }
                                 }
@@ -333,20 +334,19 @@ public class IntegrationLoader implements CommandLineRunner {
                 }
             }
             logger.info("Loaded/reloaded " + integrationCount + " home organizations.");
-
-            logger.info(idpIds.size() + " inactivated integrations.");
-            for (Long id : idpIds) {
-                Optional<Integration> inactivatedIntegration = this.integrationRepository
-                        .findByIdAll(id);
-                if (inactivatedIntegration.isPresent()) {
-                    inactivatedIntegration.get().setStatus(1);
-                    try {
-                        integrationRepository.save(inactivatedIntegration.get());
-                    } catch (Exception e) {
-                        logger.error("Integration Exception: " + e + ". Could not inactivate integration #"
-                                + inactivatedIntegration.get().getId());
-                        continue;
-                    }
+        }
+        logger.info(idpIds.size() + " inactivated integrations.");
+        for (Long id : idpIds) {
+            Optional<Integration> inactivatedIntegration = this.integrationRepository
+                    .findByIdAll(id);
+            if (inactivatedIntegration.isPresent()) {
+                inactivatedIntegration.get().setStatus(1);
+                try {
+                    integrationRepository.save(inactivatedIntegration.get());
+                } catch (Exception e) {
+                    logger.error("Integration Exception: " + e + ". Could not inactivate integration #"
+                            + inactivatedIntegration.get().getId());
+                    continue;
                 }
             }
         }

--- a/mpassid-voh-api/src/main/java/fi/mpass/voh/api/config/ServiceProvidersLoader.java
+++ b/mpassid-voh-api/src/main/java/fi/mpass/voh/api/config/ServiceProvidersLoader.java
@@ -76,7 +76,7 @@ public class ServiceProvidersLoader implements CommandLineRunner {
     public void run(String... args) throws Exception {
 
         List<Long> spIds = integrationRepository.getAllSpIds();
-        logger.debug("Number of existing sp integrations: " + spIds.size());
+        logger.info("Number of existing sp integrations: " + spIds.size());
 
         for (String spInput : this.serviceProvidersInput) {
             ObjectMapper objectMapper = new ObjectMapper();

--- a/mpassid-voh-api/src/main/java/fi/mpass/voh/api/integration/ConfigurationEntity.java
+++ b/mpassid-voh-api/src/main/java/fi/mpass/voh/api/integration/ConfigurationEntity.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import javax.persistence.OneToMany;
 import javax.persistence.OneToOne;
+import javax.persistence.OrderBy;
 import javax.persistence.PrimaryKeyJoinColumn;
 
 import org.hibernate.envers.Audited;
@@ -39,7 +40,8 @@ public class ConfigurationEntity {
     @JsonManagedReference
     @OneToMany(mappedBy = "configurationEntity", cascade = CascadeType.ALL, fetch = FetchType.EAGER, orphanRemoval = true)
     @NotAudited
-    private Set<Attribute> attributes;
+    @OrderBy("name")
+    private Set<Attribute> attributes = new HashSet<Attribute>();
 
     @OneToOne(mappedBy = "configurationEntity", cascade = CascadeType.ALL)
     @PrimaryKeyJoinColumn

--- a/mpassid-voh-app/pom.xml
+++ b/mpassid-voh-app/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>fi.mpass</groupId>
 		<artifactId>mpassid-voh</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>mpassid-voh-app</artifactId>
 

--- a/mpassid-voh-ui/pom.xml
+++ b/mpassid-voh-ui/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>fi.mpass</groupId>
 		<artifactId>mpassid-voh</artifactId>
-		<version>2.0.0</version>
+		<version>2.0.1-SNAPSHOT</version>
 	</parent>
 	<artifactId>mpassid-voh-ui</artifactId>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>fi.mpass</groupId>
     <artifactId>mpassid-voh</artifactId>
-    <version>2.0.0</version>
+    <version>2.0.1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <description>MPASSid virkailijan opintopolun hallintapalvelu</description>
     <licenses>


### PR DESCRIPTION
In a case of multiple deployment phases/environments, home organization loader incorrectly inactivated existing integrations.
The pull request includes the default sorting of configuration entity attributes by name.